### PR TITLE
Fix missing external_resource

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -357,6 +357,7 @@ defmodule Phoenix.Template do
     args =
       if given_engines, do: [root, pattern, Macro.escape(given_engines)], else: [root, pattern]
 
+    Module.put_attribute(module, :external_resource, root)
     Module.put_attribute(module, :phoenix_templates_hashes, {hash, args})
     triplets
   end


### PR DESCRIPTION
Phoenix/Elixir newcomers might follow the docs and examples to learn. When it does not work as expected, it is really hard for them to find out the cause and may lose a bit of interest in Phoenix.

Symptom: Following https://hexdocs.pm/phoenix/request_lifecycle.html , when getting to the step of creating index.html.heex the live reload fails with "Could not render "index.html" for HelloWeb.HelloView...".
Even after the template had been created.

A workaround is to recompile HelloWeb.HelloView module when index.html.heex is present, on the other hand the documentation praises live reload feature and here it does not work.

Cause: There is no external_resource in HelloWeb.HelloView at the time it is first compiled since there is no hello_web/templates/hello directory exists

Fixes also the situation when adding additional templates and views.

In case this PR is not merged, we shall consider changing the docs to reflect reality.