### PR TITLE
Add prototype for :telemetry events in render/4

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -118,10 +118,14 @@ defmodule Phoenix.Template do
 
   """
   def render(module, template, format, assigns) do
-    assigns
-    |> Map.new()
-    |> Map.pop(:layout, false)
-    |> render_within_layout(module, template, format)
+    :telemetry.span([:phoenix_template, :render], %{module: module, template: template, format: format}, fn() ->
+      result = assigns
+      |> Map.new()
+      |> Map.pop(:layout, false)
+      |> render_within_layout(module, template, format)
+
+      {result, %{}}
+    end)
   end
 
   defp render_within_layout({false, assigns}, module, template, format) do


### PR DESCRIPTION
In the current version of [AppSignal’s Phoenix integration](https://github.com/appsignal/appsignal-elixir-phoenix), we use [an extension called `Appsignal.Phoenix.View`](https://github.com/appsignal/appsignal-elixir-phoenix/blob/main/lib/appsignal_phoenix/view.ex) wich is [`use`d in Phoenix applications’ web module files](https://docs.appsignal.com/elixir/integrations/phoenix.html#template-rendering). Since Phoenix 1.7 uses phoenix_template directly, there’s no way for us to hook in anymore.

With an eye on the future, I’d like to propose adding :telemetry events to phoenix_template’s render function. That way, we can restore our functionality in AppSignal, and other APMs, as well as OpenTelemetry can subscribe to phoenix_template events instead of solutions like extending Phoenix.View.

I’m interested in hearing what you think of this proof of concept. I’ve added the metadata we’ll need (the view module, template name and format), but I’m of course open to adding more.