### PR TITLE
Show a better error message when the module doesn't exist

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -238,7 +238,12 @@ defmodule Phoenix.Template do
     if function_exported?(module, :render, 2) do
       module.render(template <> "." <> format, assigns)
     else
-      raise ArgumentError, "no \"#{template}\" #{format} template defined for #{inspect(module)}"
+      if Code.ensure_loaded?(module) do
+        raise ArgumentError,
+              "no \"#{template}\" #{format} template defined for #{inspect(module)}"
+      else
+        raise ArgumentError, "Looked for a #{inspect(module)} HTML module, but none was defined"
+      end
     end
   end
 

--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -238,12 +238,15 @@ defmodule Phoenix.Template do
     if function_exported?(module, :render, 2) do
       module.render(template <> "." <> format, assigns)
     else
-      if Code.ensure_loaded?(module) do
-        raise ArgumentError,
-              "no \"#{template}\" #{format} template defined for #{inspect(module)}"
-      else
-        raise ArgumentError, "Looked for a #{inspect(module)} HTML module, but none was defined"
-      end
+      reason =
+        if Code.ensure_loaded?(module) do
+          " (the module is defined but does define #{template}/1 nor render/2)"
+        else
+          " (the module does not exist)"
+        end
+
+      raise ArgumentError,
+            "no \"#{template}\" #{format} template defined for #{inspect(module)} #{reason}"
     end
   end
 


### PR DESCRIPTION
Example naive fix for #6

We maybe want to use a different function than `Code.ensure_loaded?/1`.